### PR TITLE
Firefox extension

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 3,
   "name": "Panda Wallet",
   "description": "A non-custodial and open-source wallet for BSV and 1Sat Ordinals",
-  "permissions": ["storage", "activeTab", "tabs", "windows"],
+  "permissions": ["storage", "activeTab", "tabs"],
   "host_permissions": [
     "https://api.whatsonchain.com/*",
     "https://ordinals.gorillapool.io/*",
@@ -14,9 +14,8 @@
     "default_title": "Panda Wallet"
   },
   "background": {
-    "service_worker": "background.js",
-    "type": "module"
-  },
+    "scripts": ["background.js"]
+  },  
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
@@ -36,5 +35,10 @@
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
-  }
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "panda-wallet-bsv@example.com"
+    }
+  }  
 }


### PR DESCRIPTION
Addressing issue #15: Made some changes to the manifest.json that were causing errors when trying to submit the code to the Firefox Addons stone (AMO - addons.mozilla.org). Finally got it working and you can download the extension [here](https://addons.mozilla.org/en-US/firefox/addon/panda-wallet/). Seems like the process has to be manual and there's no way to connect the github repo or something like that. 

Apparently there is a Mozilla tool called `web-ext` that can help streamline, but we need to do this process for every new version we want to push to the AMO.

Haven't really done this browser development stuff before so I'm not 100% what the changes to the manifest.json file fully mean but it was just a process of trial and error to get it working. Didn't break things for me on the Chrome side but would be great if someone else could make sure before it's merged.