### PR TITLE
add feature `getSignatures` to support signing arbitrary smart contract txs.

### DIFF
--- a/public/inject.js
+++ b/public/inject.js
@@ -39,4 +39,5 @@ window.panda = {
   signMessage: createPandaMethod("signMessage"),
   signTransaction: createPandaMethod("signTransaction"),
   broadcast: createPandaMethod("broadcast"),
+  getSignatures: createPandaMethod("getSignatures"),
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,12 +22,14 @@ import {
   Web3SignTransactionRequest,
 } from "./hooks/useBsv";
 import { Web3TransferOrdinalRequest } from "./hooks/useOrds";
+import { Web3GetSignaturesRequest } from "./hooks/useContracts";
 import { OrdTransferRequest } from "./pages/requests/OrdTransferRequest";
 import { BottomMenuContext } from "./contexts/BottomMenuContext";
 import { ConnectRequest } from "./pages/requests/ConnectRequest";
 import { SignMessageRequest } from "./pages/requests/SignMessageRequest";
 import { BroadcastRequest } from "./pages/requests/BroadcastRequest";
 import { SignTransactionRequest } from "./pages/requests/SignTransactionRequest";
+import { GetSignaturesRequest } from "./pages/requests/GetSignaturesRequest";
 
 export type ThirdPartyAppRequestData = {
   appName: string;
@@ -75,6 +77,10 @@ export const App = () => {
     Web3SignTransactionRequest | undefined
   >(undefined);
 
+  const [getSignaturesRequest, setGetSignaturesRequest] = useState<
+    Web3GetSignaturesRequest | undefined
+  >(undefined);
+
   useActivityDetector(isLocked);
 
   const handleUnlock = async () => {
@@ -92,6 +98,7 @@ export const App = () => {
         "signMessageRequest",
         "signTransactionRequest",
         "broadcastRequest",
+        "getSignaturesRequest",
       ],
       (result) => {
         const {
@@ -103,6 +110,7 @@ export const App = () => {
           signMessageRequest,
           signTransactionRequest,
           broadcastRequest,
+          getSignaturesRequest,
         } = result;
 
         if (popupWindowId) setPopupId(popupWindowId);
@@ -135,6 +143,10 @@ export const App = () => {
 
         if (broadcastRequest) {
           setBroadcastRequest(broadcastRequest);
+        }
+
+        if (getSignaturesRequest) {
+          setGetSignaturesRequest(getSignaturesRequest);
         }
       }
     );
@@ -171,7 +183,8 @@ export const App = () => {
                       !bsvSendRequest &&
                       !messageToSign &&
                       !broadcastRequest &&
-                      !signTransactionRequest
+                      !signTransactionRequest &&
+                      !getSignaturesRequest
                     }
                     whenFalseContent={
                       <>
@@ -204,6 +217,13 @@ export const App = () => {
                             request={broadcastRequest as Web3BroadcastRequest}
                             popupId={popupId}
                             onBroadcast={() => setBroadcastRequest(undefined)}
+                          />
+                        </Show>
+                        <Show when={!!getSignaturesRequest}>
+                          <GetSignaturesRequest
+                            getSigsRequest={getSignaturesRequest as Web3GetSignaturesRequest}
+                            popupId={popupId}
+                            onSignature={() => setGetSignaturesRequest(undefined)}
                           />
                         </Show>
                       </>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -65,10 +65,11 @@ export type ButtonProps = {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
   isSubmit?: boolean;
+  style?: React.CSSProperties;
 };
 
 export const Button = (props: ButtonProps) => {
-  const { label, type, onClick, disabled, theme, isSubmit } = props;
+  const { label, type, onClick, disabled, theme, isSubmit, style } = props;
   return (
     <>
       <Show when={type === "primary"}>
@@ -77,6 +78,7 @@ export const Button = (props: ButtonProps) => {
           disabled={disabled}
           onClick={onClick}
           type={isSubmit ? "submit" : "button"}
+          style={style}
         >
           {label}
         </Primary>
@@ -87,6 +89,7 @@ export const Button = (props: ButtonProps) => {
           disabled={disabled}
           onClick={onClick}
           type={isSubmit ? "submit" : "button"}
+          style={style}
         >
           {label}
         </Secondary>
@@ -97,6 +100,7 @@ export const Button = (props: ButtonProps) => {
           disabled={disabled}
           onClick={onClick}
           type={isSubmit ? "submit" : "button"}
+          style={style}
         >
           {label}
         </Warn>

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -65,6 +65,7 @@ export const Snackbar = (props: SnackbarProps) => {
           fontWeight: 500,
           fontSize: "1.25rem",
           color: type === "error" ? theme.white : theme.darkAccent,
+          wordWrap: "break-word",
         }}
       >
         {message}

--- a/src/contexts/SnackbarContext.tsx
+++ b/src/contexts/SnackbarContext.tsx
@@ -8,7 +8,7 @@ export type SnackbarType = "error" | "info" | "success";
 type SnackbarContextType = {
   message: string | null;
   snackBarType: SnackbarType | null;
-  addSnackbar: (message: string, type: SnackbarType) => void;
+  addSnackbar: (message: string, type: SnackbarType, duration?: number) => void;
 };
 
 export const SnackbarContext = createContext<SnackbarContextType | null>(null);
@@ -23,14 +23,14 @@ export const SnackbarProvider = (props: SnackbarProviderProps) => {
   const [message, setMessage] = useState<string | null>(null);
   const [snackBarType, setSnackBarType] = useState<SnackbarType | null>(null);
 
-  const addSnackbar = (msg: string, type: SnackbarType) => {
+  const addSnackbar = (msg: string, type: SnackbarType, duration?: number) => {
     setMessage(msg);
     setSnackBarType(type);
 
     setTimeout(() => {
       setMessage(null);
       setSnackBarType(null);
-    }, SNACKBAR_TIMEOUT);
+    }, duration || SNACKBAR_TIMEOUT);
   };
 
   return (

--- a/src/hooks/useContracts.ts
+++ b/src/hooks/useContracts.ts
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+import { useKeys } from "./useKeys";
+import { PrivateKey, Script, Transaction, TxIn } from "bsv-wasm-web";
+import { useBsvWasm } from "./useBsvWasm";
+
+/** 
+ * `SignatureRequest` contains required informations for a signer to sign a certain input of a transaction.
+ */
+export interface SignatureRequest {
+  prevTxId: string;
+  outputIndex: number;
+  /** The index of input to sign. */
+  inputIndex: number;
+  /** The previous output satoshis value of the input to spend. */
+  satoshis: number;
+  /** The address(es) of corresponding private key(s) required to sign the input. */
+  address: string | string[];
+  /** The previous output script of input, default value is a P2PKH locking script for the `address` if omitted. */
+  scriptHex?: string;
+  /** The sighash type, default value is `SIGHASH_ALL | SIGHASH_FORKID` if omitted. */
+  sigHashType?: number;
+  /** 
+   * Index of the OP_CODESEPARATOR to split the previous output script at during verification.
+   * If undefined, the whole script is used.
+   * */
+  csIdx?: number;
+  /** The extra information for signing. */
+  data?: unknown;
+}
+
+
+export type Web3GetSignaturesRequest = {
+
+  /** The raw transaction hex to get signatures from. */
+  txHex: string;
+
+  /** The signature requst informations, see details in `SignatureRequest`. */
+  sigRequests: SignatureRequest[];
+}
+
+/** 
+ * `SignatureResponse` contains the signing result corresponding to a `SignatureRequest`.
+ */
+export interface SignatureResponse {
+  /** The index of input. */
+  inputIndex: number;
+  /** The signature.*/
+  sig: string;
+  /** The public key bound with the `sig`. */
+  publicKey: string;
+  /** The sighash type, default value is `SIGHASH_ALL | SIGHASH_FORKID` if omitted. */
+  sigHashType: number;
+  /** The index of the OP_CODESEPARATOR to split the previous output script at.*/
+  csIdx?: number;
+}
+
+const DEFAULT_SIGHASH_TYPE = 65; // SIGHASH_ALL | SIGHASH_FORKID
+
+export const useContracts = () => {
+  const [isProcessing, setIsProcessing] = useState(false);
+  const { retrieveKeys, bsvAddress, ordAddress, verifyPassword } = useKeys();
+  const { bsvWasmInitialized } = useBsvWasm();
+
+  /**
+   * 
+   * @param request An object containing the raw transaction hex and signature request informations.
+   * @param password The confirm password to unlock the private keys.
+   * @returns A promise which resolves to a list of `SignatureReponse` corresponding to the `request` or an error object if any.
+   */
+  const getSignatures = async (
+    request: Web3GetSignaturesRequest,
+    password: string
+  ): Promise<{ sigResponses?: SignatureResponse[], error?: { message: string; cause?: any } }> => {
+    try {
+      if (!bsvWasmInitialized) throw Error("bsv-wasm not initialized!");
+
+      setIsProcessing(true);
+      const isAuthenticated = await verifyPassword(password);
+      if (!isAuthenticated) {
+        throw new Error('invalid-password');
+      }
+
+      const keys = await retrieveKeys(password);
+      const getPrivKeys = (address: string | string[]) => {
+        const addresses = address instanceof Array ? address : [address];
+        return addresses.map(addr => {
+          if (addr === bsvAddress) {
+            return PrivateKey.from_wif(keys.walletWif!);
+          }
+          if (addr === ordAddress) {
+            return PrivateKey.from_wif(keys.ordWif!);
+          }
+          throw new Error('unknown-address', { cause: addr });
+        });
+      }
+
+      const tx = Transaction.from_hex(request.txHex);
+      const sigResponses: SignatureResponse[] = request.sigRequests.flatMap(sigReq => {
+        const privkeys = getPrivKeys(sigReq.address);
+
+        return privkeys.map((privKey: PrivateKey) => {
+          const addr = privKey.to_public_key().to_address();
+          const script = sigReq.scriptHex ? Script.from_hex(sigReq.scriptHex) : addr.get_locking_script();
+          const txIn = tx.get_input(sigReq.inputIndex) || new TxIn(
+            Buffer.from(sigReq.prevTxId, "hex"),
+            sigReq.outputIndex,
+            script
+          );
+          txIn.set_prev_tx_id(Buffer.from(sigReq.prevTxId, "hex"));
+          txIn.set_vout(sigReq.outputIndex);
+          txIn.set_satoshis(BigInt(sigReq.satoshis));
+          txIn.set_locking_script(script);
+
+          script.remove_codeseparators();
+          // TODO: support multiple OP_CODESEPARATORs and get subScript according to `csIdx`.
+          const subScript = script;
+
+          const sig = tx.sign(
+            privKey,
+            sigReq.sigHashType || DEFAULT_SIGHASH_TYPE,
+            sigReq.inputIndex,
+            subScript,
+            BigInt(sigReq.satoshis)
+          ).to_hex();
+
+          return {
+            sig,
+            publicKey: privKey.to_public_key().to_hex(),
+            inputIndex: sigReq.inputIndex,
+            sigHashType: sigReq.sigHashType || DEFAULT_SIGHASH_TYPE,
+            csIdx: sigReq.csIdx,
+          }
+        })
+      })
+      return Promise.resolve({ sigResponses });
+    } catch (err: any) {
+      console.error('getSignatures error', err);
+      return {
+        error: {
+          message: err.message ?? 'unknown',
+          cause: err.cause,
+        }
+      };
+    } finally {
+      setIsProcessing(false);
+    }
+  }
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    isProcessing,
+    setIsProcessing,
+    getSignatures,
+  }
+}

--- a/src/pages/requests/GetSignaturesRequest.tsx
+++ b/src/pages/requests/GetSignaturesRequest.tsx
@@ -1,0 +1,301 @@
+import { useBottomMenu } from "../../hooks/useBottomMenu";
+import React, { useEffect, useState } from "react";
+import { Button } from "../../components/Button";
+import {
+  Text,
+  HeaderText,
+  ConfirmContent,
+  FormContainer,
+} from "../../components/Reusable";
+import { Show } from "../../components/Show";
+import { useSnackbar } from "../../hooks/useSnackbar";
+import { PageLoader } from "../../components/PageLoader";
+import { Input } from "../../components/Input";
+import { sleep } from "../../utils/sleep";
+import { useTheme } from "../../hooks/useTheme";
+import { DefaultTheme, styled } from "styled-components";
+import { SignatureResponse, Web3GetSignaturesRequest, useContracts } from "../../hooks/useContracts";
+import { storage } from "../../utils/storage";
+import { useNavigate } from "react-router-dom";
+import { P2PKHAddress, Transaction } from "bsv-wasm-web";
+import { useBsvWasm } from "../../hooks/useBsvWasm";
+
+const TxInput = styled.div`
+  border: 1px solid yellow;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  width: 85%;
+`;
+
+const TxOutput = styled.div`
+  border: 1px solid green;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  width: 85%;
+`;
+
+const TxContainer = styled.div`
+  max-height: 10rem;
+  overflow-y: scroll;
+`;
+
+const TxInputsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const TxOutputsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+
+const InputContent = (props: { idx: number, tag: string, addr: string | string[], sats: number, theme?: DefaultTheme | undefined }) => {
+  return (
+    <div style={{ color: props.theme?.color || 'white' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', paddingTop: '0.2rem' }}>
+        <span>#{props.idx}</span>
+        <span>{props.tag}</span>
+        <span>{props.sats} sats</span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <div>Signer:</div>
+        <div style={{ overflowX: 'scroll', padding: '0.5rem 0 0.5rem 0.5rem' }}>{props.addr}</div>
+      </div>
+    </div>
+  )
+}
+
+const OutputContent = (props: { idx: number, tag: string, addr: string | string[], sats: number, theme?: DefaultTheme | undefined }) => {
+  return (
+    <div style={{ color: props.theme?.color || 'white' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', paddingTop: '0.2rem' }}>
+        <span>#{props.idx}</span>
+        <span>{props.tag}</span>
+        <span>{props.sats} sats</span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <div>Payee:</div>
+        <div style={{ overflowX: 'scroll', padding: '0.5rem 0 0.5rem 0.5rem' }}>{props.addr}</div>
+      </div>
+    </div>
+  )
+}
+
+const TxViewer = (props: { request: Web3GetSignaturesRequest }) => {
+  const { theme } = useTheme();
+  const [showDetail, setShowDetail] = useState(false);
+  const { request } = props;
+  const { bsvWasmInitialized } = useBsvWasm();
+  const [tx, setTx] = useState<Transaction | undefined>(undefined);
+
+  useEffect(() => {
+    if (bsvWasmInitialized) {
+      setTx(Transaction.from_hex(request.txHex));
+    }
+  }, [bsvWasmInitialized, request.txHex]);
+
+  return (
+    <TxContainer>
+      <Show when={!showDetail}>
+        <Button
+          theme={theme}
+          type="secondary"
+          label="Details"
+          // disabled={isProcessing}
+          onClick={() => setShowDetail(!showDetail)}
+          style={{ marginTop: '0' }}
+        />
+      </Show>
+
+      <Show when={showDetail}>
+        <TxInputsContainer>
+          <Text theme={theme} style={{ margin: "0.5rem 0" }}>
+            Inputs To Sign
+          </Text>
+          {
+            request.sigRequests.map(sigReq => {
+              return (
+                <TxInput>
+                  <InputContent
+                    idx={sigReq.inputIndex}
+                    tag={sigReq.scriptHex ? 'nonStandard' : 'P2PKH'}
+                    addr={[sigReq.address].flat().join(', ')}
+                    sats={sigReq.satoshis}
+                    theme={theme}
+                  />
+                </TxInput>
+              )
+            })
+          }
+        </TxInputsContainer>
+        <TxOutputsContainer>
+          <Text theme={theme} style={{ margin: "0.5rem 0" }}>
+            Outputs
+          </Text>
+          {
+            tx ?
+              [...Array(tx.get_noutputs()).keys()].map((idx: number) => {
+                const output = tx.get_output(idx);
+                const asm = output!.get_script_pub_key().to_asm_string();
+                const pubkeyHash = (/^OP_DUP OP_HASH160 ([0-9a-fA-F]{40}) OP_EQUALVERIFY OP_CHECKSIG$/.exec(asm) || [])[1];
+                const isP2PKH = !!pubkeyHash;
+                const toAddr = pubkeyHash ? P2PKHAddress.from_pubkey_hash(Uint8Array.from(Buffer.from(pubkeyHash, 'hex'))).to_string() : 'Unknown Address';
+
+                return (
+                  <TxOutput>
+                    <OutputContent
+                      idx={idx}
+                      tag={isP2PKH ? 'P2PKH' : 'nonStandard'}
+                      addr={toAddr}
+                      sats={Number(output!.get_satoshis())}
+                      theme={theme}
+                    />
+                  </TxOutput>
+                )
+              })
+              : <>Parsing Tx ...</>
+          }
+        </TxOutputsContainer>
+      </Show>
+
+    </TxContainer>
+  )
+}
+
+export type GetSignaturesResponse = {
+  sigResponses?: SignatureResponse[];
+  error?: string;
+};
+
+export type GetSignaturesRequestProps = {
+  getSigsRequest: Web3GetSignaturesRequest;
+  popupId: number | undefined;
+  onSignature: () => void;
+};
+
+export const GetSignaturesRequest = (props: GetSignaturesRequestProps) => {
+  const { theme } = useTheme();
+  const { setSelected } = useBottomMenu();
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const { addSnackbar, message } = useSnackbar();
+  const navigate = useNavigate();
+
+  const { getSigsRequest, onSignature, popupId } = props;
+  const [getSigsResponse, setGetSigsRespons] = useState<any>(undefined);
+  const { isProcessing, setIsProcessing, getSignatures } = useContracts();
+
+  useEffect(() => {
+    setSelected("bsv");
+  }, [setSelected]);
+
+  useEffect(() => {
+    if (!getSigsResponse) return;
+    if (!message && getSigsResponse) {
+      resetSendState();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [message, getSigsResponse]);
+
+  const resetSendState = () => {
+    setPasswordConfirm("");
+    setGetSigsRespons(undefined);
+    setIsProcessing(false);
+  };
+
+  const handleSigning = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsProcessing(true);
+    await sleep(25);
+
+    if (!passwordConfirm) {
+      addSnackbar("You must enter a password!", "error");
+      setIsProcessing(false);
+      return;
+    }
+
+    const getSigsRes = await getSignatures(getSigsRequest, passwordConfirm);
+
+    if (getSigsRes?.error) {
+
+      const message =
+        getSigsRes.error.message === "invalid-password"
+          ? "Invalid Password!"
+          : getSigsRes.error.message === "unknown-address"
+            ? "Unknown Address: " + (getSigsRes.error.cause ?? '')
+              : "An unknown error has occurred! Try again.";
+
+      addSnackbar(message, "error", 5000);
+
+      if (getSigsRes.error.message === 'invalid-password') {
+        // could try again only if the password is wrong
+        setIsProcessing(false);
+        return;
+      }
+    }
+
+    if (getSigsRes?.sigResponses) {
+      addSnackbar("Successfully Signed!", "success");
+    }
+
+    setGetSigsRespons(getSigsRes.sigResponses);
+    onSignature();
+
+    chrome.runtime.sendMessage({
+      action: "getSignaturesResponse",
+      ...getSigsRes,
+    });
+
+    if (!getSigsRes && popupId) chrome.windows.remove(popupId);
+    storage.remove("getSignaturesRequest");
+    navigate("/bsv-wallet");
+  };
+
+  const rejectSigning = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.preventDefault();
+    if (popupId) chrome.windows.remove(popupId);
+    storage.remove("getSignaturesRequest");
+  };
+
+  return (
+    <>
+      <Show when={isProcessing}>
+        <PageLoader theme={theme} message="Signing Transaction..." />
+      </Show>
+      <Show when={!isProcessing && !!getSigsRequest}>
+        <ConfirmContent>
+          <HeaderText theme={theme}>Sign Transaction</HeaderText>
+          <Text theme={theme} style={{ margin: "0.75rem 0" }}>
+            The app is requesting signatures for a transaction.
+          </Text>
+          <FormContainer noValidate onSubmit={(e) => handleSigning(e)}>
+            <TxViewer request={getSigsRequest} />
+            <Input
+              theme={theme}
+              placeholder="Enter Wallet Password"
+              type="password"
+              onChange={(e) => setPasswordConfirm(e.target.value)}
+            />
+            <Button
+              theme={theme}
+              type="primary"
+              label="Sign the transaction"
+              isSubmit
+              disabled={isProcessing}
+            />
+            <Button
+              theme={theme}
+              type="secondary"
+              label="Cancel"
+              disabled={isProcessing}
+              onClick={rejectSigning}
+              style={{ marginTop: '0' }}
+            />
+          </FormContainer>
+        </ConfirmContent>
+      </Show>
+    </>
+  );
+};


### PR DESCRIPTION
`getSignatures` is added for signing arbitrary transaction inputs to support smart contract features.

Examples:

```ts
const sigRequests: SignatureRequest[] = [
  { 
    prevTxId: $txid_0,
    outputIndex: 0,
    inputIndex: 0,
    satoshis: 1,
    address: ordAddress,
  },
  { 
    prevTxId: $txId_1,
    outputIndex: 0,
    inputIndex: 1,
    satoshis: 1000,
    address: bsvAddress,
    scriptHex: $contract_locking_script_hex,
  }
]

const sigResponses: SignatureResponse[] = await wallet.getSignatures({
  txHex: $unsignedTxRawHex,
  sigRequests
})
```

Types:
```ts
/** 
 * `SignatureRequest` contains required informations for a signer to sign a certain input of a transaction.
 */
export interface SignatureRequest {
  prevTxId: string;
  outputIndex: number;
  /** The index of input to sign. */
  inputIndex: number;
  /** The previous output satoshis value of the input to spend. */
  satoshis: number;
  /** The address(es) of corresponding private key(s) required to sign the input. */
  address: string | string[];
  /** The previous output script of input, default value is a P2PKH locking script for the `address` if omitted. */
  scriptHex?: string;
  /** The sighash type, default value is `SIGHASH_ALL | SIGHASH_FORKID` if omitted. */
  sigHashType?: number;
  /** 
   * Index of the OP_CODESEPARATOR to split the previous output script at during verification.
   * If undefined, the whole script is used.
   * */
  csIdx?: number;
  /** The extra information for signing. */
  data?: unknown;
}

/** 
 * `SignatureResponse` contains the signing result corresponding to a `SignatureRequest`.
 */
export interface SignatureResponse {
  /** The index of input. */
  inputIndex: number;
  /** The signature.*/
  sig: string;
  /** The public key bound with the `sig`. */
  publicKey: string;
  /** The sighash type, default value is `SIGHASH_ALL | SIGHASH_FORKID` if omitted. */
  sigHashType: number;
  /** The index of the OP_CODESEPARATOR to split the previous output script at.*/
  csIdx?: number;
}
```

Default Popup Page:
<img width="359" alt="image" src="https://github.com/Panda-Wallet/panda-wallet/assets/564244/405825be-deea-4a70-b2f9-f6df29acfcbc">

Popup Page in Details:
<img width="360" alt="image" src="https://github.com/Panda-Wallet/panda-wallet/assets/564244/908ff04c-832c-495e-890c-10def9093a63">
