### PR TITLE
Change message signature to base64

### DIFF
--- a/src/hooks/useBsv.ts
+++ b/src/hooks/useBsv.ts
@@ -284,7 +284,7 @@ export const useBsv = () => {
         address,
         pubKey: publicKey.to_hex(),
         message: message,
-        sig: signature.to_compact_hex(),
+        sig: Buffer.from(signature.to_compact_hex(), 'hex').toString('base64'),
         derivationTag,
       };
     } catch (error) {


### PR DESCRIPTION
Changing the signature returned when signing a message (not tx) to be base64 instead of hex so that it is consistent with other APIs/services like relayone and paymail identity signing.