### PR TITLE
fix API issue caused by ConnectRequest

### DIFF
--- a/src/pages/requests/ConnectRequest.tsx
+++ b/src/pages/requests/ConnectRequest.tsx
@@ -62,7 +62,7 @@ export const ConnectRequest = (props: ConnectRequestProps) => {
       // We don't want the window to stay open after a successful connection. The 10ms timeout is used because of some weirdness with how chrome.sendMessage() works
       setTimeout(() => {
         if (popupId) chrome.windows.remove(popupId);
-      }, 10);
+      }, 1000);
     }
   }, [bsvPubKey, ordPubKey, popupId, thirdPartyAppRequestData, isDecided, identityPubKey]);
 
@@ -114,7 +114,16 @@ export const ConnectRequest = (props: ConnectRequestProps) => {
   };
 
   return (
-    <Show when={!thirdPartyAppRequestData?.isAuthorized}>
+    <Show
+      when={!thirdPartyAppRequestData?.isAuthorized}
+      whenFalseContent={
+        <Container>
+          <Text theme={theme} style={{ fontSize: '1.5rem', fontWeight: 700 }}>
+            Reconnecting to {thirdPartyAppRequestData?.appName} ...
+          </Text>
+        </Container>
+      }
+    >
       <Container>
         <Icon size="5rem" src={thirdPartyAppRequestData?.appIcon} />
         <HeaderText theme={theme} style={{ width: '90%' }}>


### PR DESCRIPTION
When an app attempts to reconnect to the wallet by calling 'panda.requestAuth(),' the ConnectRequest may cause an inconsistent API issue. 

For example, if a user refreshes the launch page and clicks the 'Connect to Wallet' button again, the 'ConnectRequest' page will appear and close automatically after a very short period of time. If the app then calls a wallet API, such as 'panda.getBalance(),' it may return 0, which might be unexpected.

The 'Web3Context' has some inconsistent data written to localStorage during initialization, which is the main cause of the problem. It appears difficult to change this, but we can add a time delay to allow the 'ConnectRequest' page to complete its initialization, reducing the possibility of inconsistent data.
