### PR TITLE
Problem with multiContractCall

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -48,7 +48,6 @@ const verifyAccess = async (requestingDomain) => {
       } else {
         resolve(false);
       }
-      resolve(false);
     });
   });
 };

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.4",
+  "version": "2.11.4.1",
   "manifest_version": 3,
   "name": "Panda Wallet",
   "description": "A non-custodial and open-source wallet for BSV and 1Sat Ordinals",


### PR DESCRIPTION
Hello, I have problem with multiContractCall, it works with TAALSigner but not with PandaSigner, I used code from docs.scrypt.io/advanced/how-to-call-multiple-contracts to test, it seems that in Panda after signing the second input at await SmartContract.multiContractCall, the wallet just gets back to home screen without reaching console.log('Counter, HashPuzzle contract unlock called: ', callTx.id).
I also get this, not always though:

ERROR
Cannot read properties of null (reading 'type')
TypeError: Cannot read properties of null (reading 'type')
    at HTMLDocument.onResponse (chrome-extension://mlbnicldlpdimbjdcncnklfempedeipj/inject.js:13:22)
    
I'm debugging, getting this error here:

const processGetSignaturesResponse = (response) => {
  if (!responseCallbackForGetSignaturesRequest) throw Error('Missing callback!');

Need to understand more of the flow.. maybe could be that the second popup of a multiContractCall somehow overwrites responseCallbackForGetSignaturesRequest.
Probably also not good to shoot up multiple signing popup at once, better sequential?

Mmm probably chrome.storage.local.remove(['getSignaturesRequest', 'popupWindowId']); is removing both, it should only remove the related one, or should change logic, or show popup only sequentially (the last I think it's the safest) 
Update, the problem could be let responseCallbackForGetSignaturesRequest; , it's a single var that gets overwritten by multiple input signing 
Ok modified logic to handle responseCallbacksForGetSignaturesRequest multiple inputs, but the popup asks to sign the same input, don't know why yet

Definitely a timing issues, while debugging I waited more or did step sequentially and after asking to sign the first 2 inputs, it asked for the third and final tx got broadcasted.
I suspect all these chrome.storage.local set/get working on the same key need to be fixed. Don't know if the single popup window was the intended behaviour or if multiple ones were not taken into account.
I still need to fix the same input signing stuff so it will work normally, but we should agree on the best way to fix it.

Ok, added some more logic but still far from complete, for now I can sign just by putting breakpoints in background.js at lines 94 (return processGetSignaturesResponse(message);) and 606 (updateGetSignaturesRequests(message);) and proceeding sequentially.
I need to go on with my project so I'll keep it like this until I have some more time and you are able to respond.