### PR TITLE
break-word for long token names

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -20,6 +20,7 @@ const TabContent = styled.div`
   justify-content: space-between;
   width: 100%;
   height: calc(98%);
+  word-break: break-word;
 `;
 
 const TabsWrapper = styled.div`


### PR DESCRIPTION
 a visual issue arises when the wallet has some tokens with very long names that go beyond the available 100% width

before / after:
![image](https://github.com/user-attachments/assets/572e647a-c27f-4dd2-bd3a-6ae4297bcead)
