### PR TITLE
fix: preserve recipient address when filling max BSV

### DIFF
--- a/src/pages/BsvWallet.tsx
+++ b/src/pages/BsvWallet.tsx
@@ -732,10 +732,11 @@ export const BsvWallet = () => {
     // address/paymail so we don't wipe the user's input or remount the card.
     setRecipients((prev) => [
       {
-        ...prev[0],
+        ...(prev[0] ?? {}),
         satSendAmount: maxSats,
         usdSendAmount: null,
         amountType: 'bsv',
+        error: undefined,
       },
     ]);
   };

--- a/src/pages/BsvWallet.tsx
+++ b/src/pages/BsvWallet.tsx
@@ -726,12 +726,14 @@ export const BsvWallet = () => {
   };
 
   const fillInputWithAllBsv = () => {
-    setSatSendAmount(Math.round(bsvBalance * BSV_DECIMAL_CONVERSION));
-    setRecipients([
+    const maxSats = Math.round(bsvBalance * BSV_DECIMAL_CONVERSION);
+    setSatSendAmount(maxSats);
+    // MAX is single-recipient only. Preserve the existing recipient's id and
+    // address/paymail so we don't wipe the user's input or remount the card.
+    setRecipients((prev) => [
       {
-        id: crypto.randomUUID(),
-        address: '',
-        satSendAmount: Math.round(bsvBalance * BSV_DECIMAL_CONVERSION),
+        ...prev[0],
+        satSendAmount: maxSats,
         usdSendAmount: null,
         amountType: 'bsv',
       },


### PR DESCRIPTION
Fixes #317.

The BSV MAX button replaced the entire recipients array with a blank entry, wiping the entered address/paymail and remounting the card (the "refresh" flash). It now spreads the existing recipient, keeping its id and address while only setting the max amount.

MNEE (handleFillMaxMnee) and BSV21 (handleSetMax) already preserve the address, so no change was needed there.